### PR TITLE
Fix warnings generated by gettext when creating a pot template

### DIFF
--- a/addon/appModules/thunderbird.py
+++ b/addon/appModules/thunderbird.py
@@ -580,7 +580,7 @@ class manageColumnsDialog(wx.Dialog):
 			self.Show()
 			self.Center()
 			#TRANSLATORS: the selected column moves before another column
-			ui.message(_("%s before %s") % (self.columns[c-1].name, self.columns[c].name))
+			ui.message(_("{col1} before {col2}").format(col1=self.columns[c - 1].name, col2=self.columns[c].name))
 		else:
 			beep(150, 100)
 
@@ -596,7 +596,7 @@ class manageColumnsDialog(wx.Dialog):
 			self.Show()
 			self.Center()
 			#TRANSLATORS: a column goes after another column
-			ui.message(_("%s after %s") % (self.columns[c+1].name, self.columns[c].name))
+			ui.message(_("{col1} after {col2").format(col1=self.columns[c + 1].name, col2=self.columns[c].name))
 		else:
 			beep(150, 100)
 


### PR DESCRIPTION
Currently when running `scons pot` the following warnings are shown:
```
addon\appModules\thunderbird.py:583: warning: 'msgid' format string with unnamed arguments cannot be properly localized:
                                              The translator cannot reorder the arguments.
                                              Please consider using a format string with named arguments,
                                              and a mapping instead of a tuple for the arguments.
addon\appModules\thunderbird.py:599: warning: 'msgid' format string with unnamed arguments cannot be properly localized:
                                              The translator cannot reorder the arguments.
                                              Please consider using a format string with named arguments,
                                              and a mapping instead of a tuple for the arguments.
```


This PR uses format specifiers in these messages so that gettext no longer warns about them.