### PR TITLE
Revert "Fix warnings generated by gettext when creating a pot template"

### DIFF
--- a/addon/appModules/thunderbird.py
+++ b/addon/appModules/thunderbird.py
@@ -580,7 +580,7 @@ class manageColumnsDialog(wx.Dialog):
 			self.Show()
 			self.Center()
 			#TRANSLATORS: the selected column moves before another column
-			ui.message(_("{col1} before {col2}").format(col1=self.columns[c - 1].name, col2=self.columns[c].name))
+			ui.message(_("%s before %s") % (self.columns[c-1].name, self.columns[c].name))
 		else:
 			beep(150, 100)
 
@@ -596,7 +596,7 @@ class manageColumnsDialog(wx.Dialog):
 			self.Show()
 			self.Center()
 			#TRANSLATORS: a column goes after another column
-			ui.message(_("{col1} after {col2").format(col1=self.columns[c + 1].name, col2=self.columns[c].name))
+			ui.message(_("%s after %s") % (self.columns[c+1].name, self.columns[c].name))
 		else:
 			beep(150, 100)
 


### PR DESCRIPTION
Reverts javidominguez/MozillaScripts#11
I have reversed this change because it breaks the translations that were already done previously. There is also an error on line 599: You forgot a }. However, I will keep this issue in mind. I have moved the modification to a development branch where I am going to format all the strings by following this method. Along with other changes I will include it in a future release. Then the translators will have to modify several strings.