### PR TITLE
thunderbird: replace deprecated wx.NewId() that crashes the settings panel on wxPython 4.2

### DIFF
--- a/addon/appModules/thunderbird.py
+++ b/addon/appModules/thunderbird.py
@@ -516,7 +516,7 @@ class ThunderbirdPanel(SettingsPanel):
 	#TRANSLATORS: Settings panel title
 	title=_("Mozilla Thunderbird")
 	def makeSettings(self, sizer):
-		self.automaticMessageReading =wx.CheckBox(self, wx.NewId(), label=_("Automatically read message preview pane"))
+		self.automaticMessageReading =wx.CheckBox(self, wx.ID_ANY, label=_("Automatically read message preview pane"))
 		self.automaticMessageReading.SetValue(config.conf["thunderbird"]["automaticMessageReading"])
 		sizer.Add(self.automaticMessageReading,border=10,flag=wx.BOTTOM)
 


### PR DESCRIPTION
## Summary

Opening the **Mozilla Thunderbird** settings panel (`ThunderbirdPanel.makeSettings`) crashes on current NVDA because it builds a `wx.CheckBox` with an id from the deprecated `wx.NewId()`.

`wx.NewId()` is deprecated in wxPython 4.2.x and draws from a global counter that can return ids `>= 32767`, outside the valid control-id range. wxWidgets then fails its id assertion, the control constructor returns `NULL`, and Python raises `SystemError` / `wxAssertionError`.

## Traceback (NVDA 2026.2, wxPython 4.2.4)

```
File "...\Mozilla\appModules\thunderbird.py", line 519, in makeSettings
  self.automaticMessageReading =wx.CheckBox(self, wx.NewId(), label=_("Automatically read message preview pane"))
wx._core.wxAssertionError: C++ assertion "id == wxID_ANY || (id >= 0 && id < 32767) || ..." failed ... invalid id value
SystemError: <class 'wx._core.CheckBox'> returned NULL without setting an exception
```

## Fix

Use `wx.ID_ANY` (auto-assign) — the standard replacement for controls whose id is not referenced elsewhere. The checkbox value is accessed via `self.automaticMessageReading` (not by id), so behavior is unchanged. This was the only `wx.NewId()` usage in the file.

## Testing
- `ast.parse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
